### PR TITLE
Change Kernel and Tool fetching from snbforums to github

### DIFF
--- a/wg_manager.sh
+++ b/wg_manager.sh
@@ -342,7 +342,7 @@ Download_Modules() {
 
     #[ ! -d "${INSTALL_DIR}" ] && mkdir -p "${INSTALL_DIR}"
 
-    local WEBFILE_NAMES=$(curl -${SILENT}fL https://www.snbforums.com/threads/experimental-wireguard-for-hnd-platform-4-1-x-kernels.46164/ | grep "<a href=.*odkrys.*wireguard" | grep -oE "wireguard.*" | sed 's/\"//g' | tr '\n' ' ')
+    local WEBFILE_NAMES=$(curl -${SILENT}fL https://api.github.com/repos/odkrys/entware-makefile-for-merlin/git/trees/main | grep "\"path\": \"wireguard-.*\.ipk\"," | cut -d'"' -f 4 | tr '\r\n' ' ')
 
     # The file list MAY NOT ALWAYS be in the correct Router Model order for the following 'case' statement?
     case "$ROUTER" in
@@ -453,7 +453,7 @@ Check_Module_Versions() {
 
         # Check if Kernel and User Tools Update available
         echo -e $cBWHT"\tChecking for WireGuard Kernel and Userspace Tool updates..."
-        local FILES=$(curl -${SILENT}fL https://www.snbforums.com/threads/experimental-wireguard-for-hnd-platform-4-1-x-kernels.46164/ | grep "<a href=.*odkrys.*wireguard" | sed 's/"//g; s/\n/ /g' | grep -oE "wireguard.*")
+        local FILES=$(curl -${SILENT}fL https://api.github.com/repos/odkrys/entware-makefile-for-merlin/git/trees/main | grep "\"path\": \"wireguard-.*\.ipk\"," | cut -d'"' -f 4 | tr '\r\n' ' ')
 
         [ -z "$(echo "$FILES" | grep -F "$WGKERNEL")" ] && { echo -e $cBYEL"\t\tKernel UPDATE available" $FILE; local UPDATES="Y"; }
         [ -z "$(echo "$FILES" | grep -F "$WGTOOLS")" ] && { echo -e $cBYEL"\t\tUserspace Tool UPDATE available" $FILE; local UPDATES="Y"; }


### PR DESCRIPTION
When I tried to install wireguard on my router using this script, the "curl" command to fetch the download URLs for the wireguard kernel and tool gave me an HTTP 403. Most likely its because the forum is blocking "curl" commands into their message board to prevent bots from crawling and/or DDOS'ing it.

Instead, I feel we should be using GitHub's REST API to directly fetch the list of *.ipk files from odkrys's repo.

Although this code can easily break if odkrys decides to add more than 4 *.ipk files in his repo, I feel this is better than scraping snbforums.

Let me know what you think!

Btw, awesome job creating this script!